### PR TITLE
Replace Google Tag Manager with Google Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>soran.link | そら VRC</title>
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-5TM9SGP7');</script>
-    <!-- End Google Tag Manager -->
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J65DGZPM49"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-J65DGZPM49');
+    </script>
     <meta property="og:title" content="soran.link | そら">
     <meta property="og:description" content="VRChatで遊んでいる「そら」のサイトです。">
     <meta property="og:image" content="https://soran.link/img/ogp.jpg">
@@ -55,10 +57,6 @@
     </style>
 </head>
 <body class="text-slate-700">
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5TM9SGP7"
-                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
 <div id="content-wrapper" class="max-w-4xl mx-auto my-12 md:my-24 bg-white/90 backdrop-blur-sm rounded-2xl shadow-2xl overflow-hidden">
     <main class="p-6 sm:p-10 md:p-16">
         <section id="hero" class="text-center pt-12 pb-16 md:pb-24">


### PR DESCRIPTION
This pull request updates the website to replace Google Tag Manager with a direct integration of Google Analytics in `index.html`. This ensures better tracking and analytics performance.